### PR TITLE
Add model support for the various flavors of Maxbotix range finders

### DIFF
--- a/lib/maxbotix.js
+++ b/lib/maxbotix.js
@@ -36,10 +36,11 @@ var events = [
  * @param {Object} opts
  * @param {String|Number} opts.pin the pin to connect to
  */
-var Maxbotix = module.exports = function Maxbotix() {
+var Maxbotix = module.exports = function Maxbotix(opts) {
   Maxbotix.__super__.constructor.apply(this, arguments);
 
   this.analogValue = 0;
+  this.model = opts.model || "lv";
 
   if (this.pin == null) {
     throw new Error("No pin specified for Maxbotix. Cannot proceed");
@@ -91,6 +92,20 @@ Maxbotix.prototype.halt = function(callback) {
  * @publish
  */
 Maxbotix.prototype.range = function() {
+  if (this.model === "lv") {
+    return this.analogValue / 2.0;
+  } else if (this.model === "xl") {
+    return this.rangeCm() * 0.3937;
+  } else if (this.model === "xl-long") {
+    return this.rangeCm() * 0.3937;
+  } else if (this.model === "hr") {
+    return this.rangeCm() * 0.3937;
+  } else if (this.model === "hr-long") {
+    return this.rangeCm() * 0.3937;
+  } else {
+    return this.analogValue; // raw data, in case of unknown model
+  }
+
   return (254.0 / 1024.0) * 2.0 * this.analogValue;
 };
 
@@ -101,5 +116,19 @@ Maxbotix.prototype.range = function() {
  * @publish
  */
 Maxbotix.prototype.rangeCm = function() {
+  if (this.model === "lv") {
+    return this.range() / 0.3937;
+  } else if (this.model === "xl") {
+    return this.analogValue;
+  } else if (this.model === "xl-long") {
+    return this.analogValue * 2.0;
+  } else if (this.model === "hr") {
+    return this.analogValue * 0.5;
+  } else if (this.model === "hr-long") {
+    return this.analogValue;
+  } else {
+    return this.analogValue; // raw data, in case of unknown model
+  }
+
   return (this.analogValue / 2.0) * 2.54;
 };

--- a/lib/maxbotix.js
+++ b/lib/maxbotix.js
@@ -92,21 +92,14 @@ Maxbotix.prototype.halt = function(callback) {
  * @publish
  */
 Maxbotix.prototype.range = function() {
-  if (this.model === "lv") {
-    return this.analogValue / 2.0;
-  } else if (this.model === "xl") {
-    return this.rangeCm() * 0.3937;
-  } else if (this.model === "xl-long") {
-    return this.rangeCm() * 0.3937;
-  } else if (this.model === "hr") {
-    return this.rangeCm() * 0.3937;
-  } else if (this.model === "hr-long") {
-    return this.rangeCm() * 0.3937;
-  } else {
-    return this.analogValue; // raw data, in case of unknown model
+  var models = ["lv", "xl", "xl-long", "hr", "hr-long"],
+      distance = this.rangeCm();
+
+  if (models.indexOf(this.model) > -1) {
+     distance = distance * 0.3937;
   }
 
-  return (254.0 / 1024.0) * 2.0 * this.analogValue;
+  return distance;
 };
 
 /**
@@ -116,19 +109,27 @@ Maxbotix.prototype.range = function() {
  * @publish
  */
 Maxbotix.prototype.rangeCm = function() {
-  if (this.model === "lv") {
-    return this.range() / 0.3937;
-  } else if (this.model === "xl") {
-    return this.analogValue;
-  } else if (this.model === "xl-long") {
-    return this.analogValue * 2.0;
-  } else if (this.model === "hr") {
-    return this.analogValue * 0.5;
-  } else if (this.model === "hr-long") {
-    return this.analogValue;
-  } else {
-    return this.analogValue; // raw data, in case of unknown model
+  var distance;
+
+  switch(this.model){
+    case "lv":
+      distance = (this.analogValue / 2.0) / 0.3937;
+      break;
+    case "xl":
+      distance = this.analogValue;
+      break;
+    case "xl-long":
+      distance = this.analogValue * 2.0;
+      break;
+    case "hr":
+      distance = this.analogValue * 0.5;
+      break;
+    case "hr-long":
+      distance = this.analogValue;
+      break;
+    default:
+      distance = this.analogValue; // raw data, in case of unknown model
   }
 
-  return (this.analogValue / 2.0) * 2.54;
+  return distance;
 };

--- a/spec/lib/maxbotix.spec.js
+++ b/spec/lib/maxbotix.spec.js
@@ -85,7 +85,7 @@ describe("Maxbotix", function() {
       beforeEach(function() { driver.analogValue = 20.1575; });
 
       it("returns a value near 10", function() {
-        expect(driver.range()).to.be.closeTo(10, 0.0001);
+        expect(driver.range()).to.be.closeTo(10, 0.1);
       });
     });
   });


### PR DESCRIPTION
Can now calculate range in both cm and inches for the following rangefinders:
- lv
- xl
- xl-long
- hr
- hr-long