### PR TITLE
Adds support for Relay boards.

### DIFF
--- a/lib/cylon-gpio.js
+++ b/lib/cylon-gpio.js
@@ -20,6 +20,7 @@ var Drivers = {
   "servo": require("./servo"),
   "ir-range-sensor": require("./ir-range-sensor"),
   "direct-pin": require("./direct-pin"),
+  "relay": require("./relay"),
   "rgb-led": require("./rgb-led")
 };
 

--- a/lib/relay.js
+++ b/lib/relay.js
@@ -1,0 +1,131 @@
+/*
+ * Relay driver
+ * http://cylonjs.com
+ *
+ * Copyright (c) 2013-2015 The Hybrid Group
+ * Licensed under the Apache 2.0 license.
+*/
+
+"use strict";
+
+var Cylon = require("cylon");
+
+/**
+ * A Relay driver
+ *
+ * @constructor relay
+ *
+ * @param {Object} opts
+ * @param {String|Number} opts.pin the pin to connect to
+ * @param {String} opts.type
+ */
+var Relay = module.exports = function Relay(opts) {
+  Relay.__super__.constructor.apply(this, arguments);
+
+  this.type = opts.type || "NO";
+
+  this.state = {
+    isInverted: opts.type === "NC",
+    isOn: false
+  };
+
+  if (this.pin == null) {
+    throw new Error("No pin specified for Relay. Cannot proceed");
+  }
+
+  this.commands = {
+    turn_on: this.turnOn,
+    turn_off: this.turnOff,
+    toggle: this.toggle
+  };
+
+  Object.defineProperties(this, {
+    type: {
+      get: function() {
+        return this.state.isInverted ? "NC" : "NO";
+      }
+    },
+    isOn: {
+      get: function() {
+        return this.state.isOn;
+      }
+    }
+  });
+};
+
+/** Subclasses the Cylon.Driver class */
+Cylon.Utils.subclass(Relay, Cylon.Driver);
+
+/**
+ * Starts the Relay
+ *
+ * @param {Function} callback to be triggered when started
+ * @return {null}
+ */
+Relay.prototype.start = function(callback) {
+  callback();
+};
+
+/**
+ * Stops the Relay
+ *
+ * @param {Function} callback to be triggered when halted
+ * @return {null}
+ */
+Relay.prototype.halt = function(callback) {
+  callback();
+};
+
+/**
+ * Writes a HIGH (1) value to the pin, turning the Relay on.
+ *
+ * Also sets `this.isOn` to `true`.
+ *
+ * @param {Function} [callback] - (err, val) triggers when write is complete
+ * @return {null}
+ * @publish
+ */
+Relay.prototype.turnOn = function(callback) {
+  var state = this.state;
+
+  this.connection.digitalWrite(
+    this.pin, state.isInverted ? 0 : 1, callback);
+  state.isOn = true;
+};
+
+/**
+ * Writes a LOW (0) value to the pin, turning the Relay off.
+ *
+ * Also sets `this.isOn` to `false`.
+ *
+ * @param {Function} [callback] - (err, val) triggers when write is complete
+ * @return {null}
+ * @publish
+ */
+Relay.prototype.turnOff = function(callback) {
+  var state = this.state;
+
+  this.connection.digitalWrite(
+    this.pin, state.isInverted ? 1 : 0, callback);
+  state.isOn = false;
+};
+
+/**
+ * Toggles the Relay on or off, depending on its current state
+ *
+ * @return {null}
+ * @publish
+ */
+Relay.prototype.toggle = function(callback) {
+  var state = this.state;
+
+  if (state.isOn) {
+    this.turnOff();
+  } else {
+    this.turnOn();
+  }
+
+  if (typeof callback === "function") {
+    callback();
+  }
+};

--- a/spec/lib/cylon-gpio.spec.js
+++ b/spec/lib/cylon-gpio.spec.js
@@ -13,6 +13,7 @@ var AnalogSensor = source("analog-sensor"),
     Servo = source("servo"),
     IrRangeSensor = source("ir-range-sensor"),
     DirectPin = source("direct-pin"),
+    Relay = source("relay"),
     RGBLed = source("rgb-led");
 
 describe("GPIO", function() {
@@ -31,6 +32,7 @@ describe("GPIO", function() {
         "servo",
         "ir-range-sensor",
         "direct-pin",
+        "relay",
         "rgb-led"
       ];
 
@@ -107,6 +109,12 @@ describe("GPIO", function() {
       opts.driver = "direct-pin";
       driver = mod.driver(opts);
       expect(driver).to.be.an.instanceOf(DirectPin);
+    });
+
+    it("can instantiate a new Relay", function() {
+      opts.driver = "relay";
+      driver = mod.driver(opts);
+      expect(driver).to.be.an.instanceOf(Relay);
     });
 
     it("can instantiate a new RGB LED", function() {

--- a/spec/lib/relay.spec.js
+++ b/spec/lib/relay.spec.js
@@ -1,0 +1,140 @@
+/* jshint expr:true */
+"use strict";
+
+var Relay = source("relay");
+
+describe("Relay", function() {
+  var driver;
+
+  beforeEach(function() {
+    driver = new Relay({
+      name: "switchy",
+      connection: { digitalWrite: spy(), pwmWrite: spy() },
+      pin: 13
+    });
+  });
+
+  describe("constructor", function() {
+    it("sets @pin to the value of the passed pin", function() {
+      expect(driver.pin).to.be.eql(13);
+    });
+
+    it("sets @isOn to false by default", function() {
+      expect(driver.state.isOn).to.be.false;
+    });
+
+    context("if no pin is specified", function() {
+      it("throws an error", function() {
+        var fn = function() { return new Relay({ name: "hi" }); };
+        expect(fn).to.throw("No pin specified for Relay. Cannot proceed");
+      });
+    });
+  });
+
+  it("has Relay commands", function() {
+    for (var c in driver.commands) {
+      expect(driver.commands[c]).to.be.a("function");
+    }
+  });
+
+  describe("#start", function() {
+    var callback =spy();
+
+    beforeEach(function() {
+      driver.start(callback);
+    });
+
+    it("triggers the callback", function() {
+      expect(callback).to.be.calledOnce;
+    });
+  });
+
+  describe("#halt", function() {
+    var callback =spy();
+
+    beforeEach(function() {
+      driver.halt(callback);
+    });
+
+    it("triggers the callback", function() {
+      expect(callback).to.be.calledOnce;
+    });
+  });
+
+  describe("#turnOn", function() {
+    it("writes a high value to the pin", function() {
+      driver.state.isOn = false;
+      driver.turnOn();
+
+      expect(driver.state.isOn).to.be.true;
+      expect(driver.connection.digitalWrite).to.be.calledWith(13 ,1);
+    });
+  });
+
+  describe("#turnOff", function() {
+    it("writes a high value to the pin", function() {
+      driver.state.isOn = true;
+      driver.turnOff();
+
+      expect(driver.state.isOn).to.be.false;
+      expect(driver.connection.digitalWrite).to.be.calledWith(13, 0);
+    });
+  });
+
+  describe("#toggle", function() {
+    context("when @isOn is true", function() {
+      beforeEach(function() {
+        driver.state.isOn = true;
+        stub(driver, "turnOff");
+      });
+
+      after(function() {
+        driver.turnOff.restore();
+      });
+
+      it("turns the Relay off", function() {
+        driver.toggle();
+        expect(driver.turnOff).to.be.called;
+      });
+    });
+
+    context("when @isOn is false", function() {
+      beforeEach(function() {
+        driver.state.isOn = false;
+        stub(driver, "turnOn");
+      });
+
+      after(function() {
+        driver.turnOn.restore();
+      });
+
+      it("turns the Relay on", function() {
+        driver.toggle();
+        expect(driver.turnOn).to.be.called;
+      });
+    });
+  });
+
+  describe("#isInverted", function() {
+    context("when @isInverted is true", function() {
+      beforeEach(function() {
+        driver.state.isInverted = true;
+        driver.state.isOn = true;
+        stub(driver, "turnOff");
+      });
+
+      after(function() {
+        driver.turnOff.restore();
+      });
+
+      it("sets @isInverted to true", function() {
+        expect(driver.state.isInverted).to.be.true;
+      });
+
+      it("turns the Relay off", function() {
+        driver.toggle();
+        expect(driver.turnOff).to.be.called;
+      });
+    });
+  });
+});


### PR DESCRIPTION
Adds support for both Normally Open and Normally Closed relay boards. Can change between the type at creation so that the on/off/toggle functions are mapped correctly, defaults to Normally Open.

# Usage
```javascript
var Cylon = require('cylon');

// Initialize the robot
Cylon.robot({
  connections: {
    arduino: { adaptor: 'firmata', port: '/dev/ttyACM0' }
  },

  devices: {
    relay: { driver: 'relay', pin: 13, type: "NC" }
  },

  work: function(my) {
    every((1).second(), function() {
      my.relay.toggle();
    });
}).start();
```
