### PR TITLE
Changed continuous-servo ccw value to 0

### DIFF
--- a/lib/continuous-servo.js
+++ b/lib/continuous-servo.js
@@ -113,7 +113,7 @@ ContinuousServo.prototype.counterClockwise = function(callback) {
  * @publish
  */
 ContinuousServo.prototype.rotate = function(direction, callback) {
-  var spin = (direction === "clockwise") ? 180 : 89;
+  var spin = (direction === "clockwise") ? 180 : 0;
 
   var scaledDuty = (spin).fromScale(
     this.pwmScale.bottom,

--- a/spec/lib/continuous-servo.spec.js
+++ b/spec/lib/continuous-servo.spec.js
@@ -59,7 +59,7 @@ describe("ContinuousServo", function() {
     it("writes a scaled value of 0.49 when counter-clockwise", function() {
       driver.rotate("counter-clockwise", callback);
       expect(driver.connection.servoWrite).to.be
-        .calledWith(13, 0.49444444444444446, null, { min: 500, max: 2400 });
+        .calledWith(13, 0, null, { min: 500, max: 2400 });
     });
   });
 
@@ -76,7 +76,7 @@ describe("ContinuousServo", function() {
       driver.counterClockwise(callback);
       expect(driver.connection.servoWrite).to.be.calledWith(
         13,
-        0.49444444444444446,
+        0,
         null,
         { min: 500, max: 2400 },
         callback


### PR DESCRIPTION
A value of 89 is not far enough from the rest point to move the servo.  Because 180 is the extreme value for the clockwise rotation, I think it makes sense to set counterclockwise to the opposite extreme - this provides uniform rotation in either direction.

This addresses issue #33 